### PR TITLE
[RFR] Quoting service parameters to be sf3.1 compliant

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,7 +1,7 @@
 services:
     sitemap_gz_dumper:
         class: SitemapGenerator\Dumper\GzFileDumper
-        arguments: [ %kernel.root_dir%/../web/sitemap.xml.gz ]
+        arguments: [ "%kernel.root_dir%/../web/sitemap.xml.gz" ]
 
     sitemap_xml_formatter:
         class: SitemapGenerator\Formatter\XmlFormatter


### PR DESCRIPTION
I forgot to quote the sitemap_gz_dumper argument