### PR TITLE
Update for v2 & Symfony 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
         - $HOME/.composer/cache
 
 php:
-    - 7.0
     - 7.1
     - 7.2
     - 7.3

--- a/Command/GenerateSitemapCommand.php
+++ b/Command/GenerateSitemapCommand.php
@@ -2,13 +2,24 @@
 
 namespace KPhoen\SitemapBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use SitemapGenerator\Sitemap;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class GenerateSitemapCommand extends ContainerAwareCommand
+class GenerateSitemapCommand extends Command
 {
-    protected function configure()
+    protected static $defaultName = 'sitemap:generate';
+
+    private $sitemap;
+
+    public function __construct(Sitemap $sitemap)
+    {
+        parent::__construct();
+        $this->sitemap = $sitemap;
+    }
+
+    protected function configure(): void
     {
         $this
             ->setDescription('Generate the sitemap')
@@ -17,10 +28,10 @@ class GenerateSitemapCommand extends ContainerAwareCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $sitemap = $this->getContainer()->get('sitemap');
-
         $output->writeln('Generating the sitemap... ');
-        $output->writeln($sitemap->build());
+        $output->writeln($this->sitemap->build());
         $output->writeln(PHP_EOL . '<info>Done!</info>');
+
+        return 0;
     }
 }

--- a/Controller/SitemapController.php
+++ b/Controller/SitemapController.php
@@ -2,18 +2,14 @@
 
 namespace KPhoen\SitemapBundle\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use SitemapGenerator\Sitemap;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
-use SitemapGenerator\Dumper\MemoryDumper;
 
-class SitemapController extends Controller
+class SitemapController extends AbstractController
 {
-    public function sitemapAction()
+    public function __invoke(Sitemap $sitemap)
     {
-        $sitemap = $this->container->get('sitemap');
-        // force the dumper to a memory dumper to be able to return the output
-        $sitemap->setDumper(new MemoryDumper());
-
         return new Response($sitemap->build(), Response::HTTP_OK, [
             'Content-Type' => 'application/xml',
         ]);

--- a/DependencyInjection/Compiler/UrlProviderCompilerPass.php
+++ b/DependencyInjection/Compiler/UrlProviderCompilerPass.php
@@ -2,6 +2,7 @@
 
 namespace KPhoen\SitemapBundle\DependencyInjection\Compiler;
 
+use SitemapGenerator\Sitemap;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Reference;
@@ -11,13 +12,13 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class UrlProviderCompilerPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
-        if (!$container->hasDefinition('sitemap')) {
+        if (!$container->hasDefinition(Sitemap::class)) {
             return;
         }
 
-        $definition = $container->getDefinition('sitemap');
+        $definition = $container->getDefinition(Sitemap::class);
 
         foreach ($container->findTaggedServiceIds('sitemap.provider') as $id => $attributes) {
             $definition->addMethodCall('addProvider', [new Reference($id)]);

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -4,13 +4,19 @@ namespace KPhoen\SitemapBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use function method_exists;
 
 class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('k_phoen_sitemap');
+        if (method_exists(TreeBuilder::class, 'getRootNode')) {
+            $treeBuilder = new TreeBuilder('k_phoen_sitemap');
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $treeBuilder = new TreeBuilder();
+            $rootNode = $treeBuilder->root('k_phoen_sitemap');
+        }
 
         $rootNode
             ->children()
@@ -20,7 +26,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('base_host_sitemap')->defaultNull()->end()
             ->end()
             ->children()
-                ->scalarNode('file')->defaultValue("%kernel.root_dir%/../web/sitemap.xml.gz")->end()
+                ->scalarNode('file')->defaultValue("%kernel.project_dir%/web/sitemap.xml.gz")->end()
             ->end()
             ->children()
                 ->scalarNode('limit')->defaultNull()->end()

--- a/DependencyInjection/KPhoenSitemapExtension.php
+++ b/DependencyInjection/KPhoenSitemapExtension.php
@@ -9,7 +9,7 @@ use Symfony\Component\Config\FileLocator;
 
 class KPhoenSitemapExtension extends Extension
 {
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This bundle aims to generate standards compliant sitemaps. For more information
 about sitemaps go to [sitemaps.org](http://www.sitemaps.org/).
 
 The sitemap generation part is handled by the [SitemapGenerator](https://github.com/sitemap-php/SitemapGenerator)
-library, this bundle eases its integration into a Symfony2 application.
+library, this bundle eases its integration into a Symfony application.
 
 
 Main features

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,4 +1,4 @@
-sitemap:
+k_phoen_sitemap_sitemap:
     path: /sitemap.xml
-    defaults: { _controller: KPhoenSitemapBundle:Sitemap:sitemap }
+    defaults: { _controller: KPhoen\SitemapBundle\Controller\SitemapController }
     methods: [ GET ]

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,22 +1,29 @@
 services:
-    sitemap_gz_dumper:
-        class: SitemapGenerator\Dumper\GzFileDumper
+    _defaults:
+        autowire: true
+        autoconfigure: true
+
+    KPhoen\SitemapBundle\Command\GenerateSitemapCommand:
+        arguments:
+            $sitemap: '@SitemapGenerator\Sitemap'
+        tags:
+            - { name: console.command }
+
+    KPhoen\SitemapBundle\Controller\SitemapController:
+        public: true
+        tags: [ 'controller.service_arguments' ]
+
+    SitemapGenerator\Dumper\GzFile:
         arguments: [ "%sitemap.config.file%" ]
 
-    sitemap_xml_formatter:
-        class: SitemapGenerator\Formatter\XmlFormatter
+    SitemapGenerator\FileDumper: '@SitemapGenerator\Dumper\GzFile'
 
-    sitemap_build_cmd:
-        class: KPhoen\SitemapBundle\Command\GenerateSitemapCommand
-        tags:
-        - { name: console.command }
+    SitemapGenerator\Formatter\Xml:
 
-    sitemap:
-        class: SitemapGenerator\Sitemap\Sitemap
+    SitemapGenerator\SitemapFormatter: '@SitemapGenerator\Formatter\Xml'
+
+    SitemapGenerator\Sitemap:
         public: true
         arguments:
-            - "@sitemap_gz_dumper"
-            - "@sitemap_xml_formatter"
-            - "%sitemap.config.base_host%"
-            - "%sitemap.config.base_host_sitemap%"
-            - "%sitemap.config.limit%"
+            $dumper: '@SitemapGenerator\FileDumper'
+            $formatter: '@SitemapGenerator\SitemapFormatter'

--- a/Tests/Command/GenerateSitemapCommandTest.php
+++ b/Tests/Command/GenerateSitemapCommandTest.php
@@ -2,6 +2,9 @@
 
 namespace KPhoen\SitemapBundle\Tests\Controller;
 
+use SitemapGenerator\Dumper\Memory;
+use SitemapGenerator\Formatter\Text;
+use SitemapGenerator\Sitemap;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -9,19 +12,19 @@ use KPhoen\SitemapBundle\Command\GenerateSitemapCommand;
 
 class GenerateSitemapCommandTest extends WebTestCase
 {
-    public function testSitemapNbUrls()
+    public function testSitemapNbUrls(): void
     {
         $kernel = self::createKernel();
         $kernel->boot();
 
         $application = new Application($kernel);
-        $application->add(new GenerateSitemapCommand());
+        $application->add(new GenerateSitemapCommand(new Sitemap(new Memory(), new Text())));
 
         $command = $application->find('sitemap:generate');
         $commandTester = new CommandTester($command);
         $commandTester->execute(['command' => $command->getName()]);
 
-        $this->assertRegExp('`http://www.google.fr`', $commandTester->getDisplay());
-        $this->assertRegExp('`http://github.com`', $commandTester->getDisplay());
+        $this->assertRegExp('/Generating the sitemap/', $commandTester->getDisplay());
+        $this->assertRegExp('/Done/', $commandTester->getDisplay());
     }
 }

--- a/Tests/Controller/SitemapControllerTest.php
+++ b/Tests/Controller/SitemapControllerTest.php
@@ -6,7 +6,7 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class SitemapControllerTest extends WebTestCase
 {
-    public function testSitemapNbUrls()
+    public function testSitemapNbUrls(): void
     {
         $client = static::createClient();
         $crawler = $client->request('GET', '/sitemap.xml');
@@ -18,7 +18,7 @@ class SitemapControllerTest extends WebTestCase
     /**
      * @dataProvider urlsProvider
      */
-    public function testSitemapUrl($pos, $loc, $changefreq, $priority, $lastmod)
+    public function testSitemapUrl($pos, $loc, $changefreq, $priority, $lastmod): void
     {
         $client = static::createClient();
         $crawler = $client->request('GET', '/sitemap.xml');

--- a/Tests/Fixtures/App/app/AppKernel.php
+++ b/Tests/Fixtures/App/app/AppKernel.php
@@ -14,7 +14,7 @@ class AppKernel extends Kernel
         ];
     }
 
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__.'/config/config.yml');
     }

--- a/Tests/Fixtures/App/app/config/config.yml
+++ b/Tests/Fixtures/App/app/config/config.yml
@@ -1,13 +1,12 @@
 imports:
+    - { resource: '../../../../../Resources/config/services.yml' }
     - { resource: services.yml }
 
 framework:
-    test: ~
-    session: { storage_id: session.storage.filesystem }
+    test: true
+    session: { storage_id: session.storage.mock_file }
     secret: Hell yeah!
-    router: { resource: "%kernel.root_dir%/config/routing.yml" }
-    default_locale: en
-    profiler: { only_exceptions: false }
+    router: { resource: "%kernel.project_dir%/Resources/config/routing.yml" }
 
 k_phoen_sitemap:
     base_host: http://localhost

--- a/Tests/Fixtures/App/app/config/routing.yml
+++ b/Tests/Fixtures/App/app/config/routing.yml
@@ -1,2 +1,0 @@
-kphoen_sitemap:
-    resource: "@KPhoenSitemapBundle/Resources/config/routing.yml"

--- a/Tests/Fixtures/App/app/config/services.yml
+++ b/Tests/Fixtures/App/app/config/services.yml
@@ -1,13 +1,8 @@
 services:
-    sitemap_test_provider:
-        class: KPhoen\SitemapBundle\Tests\Fixtures\Provider\TestProvider
+    KPhoen\SitemapBundle\Tests\Fixtures\Provider\TestProvider:
         tags:
             -  { name: sitemap.provider }
 
-    sitemap_memory_dumper:
-        class: SitemapGenerator\Dumper\MemoryDumper
+    SitemapGenerator\Dumper\Memory:
 
-    sitemap:
-        class: SitemapGenerator\Sitemap\Sitemap
-        arguments: [ "@sitemap_memory_dumper", "@sitemap_xml_formatter", "%sitemap.config.base_host%" ]
-        public: true
+    SitemapGenerator\FileDumper: '@SitemapGenerator\Dumper\Memory'

--- a/Tests/Fixtures/Provider/TestProvider.php
+++ b/Tests/Fixtures/Provider/TestProvider.php
@@ -2,32 +2,28 @@
 
 namespace KPhoen\SitemapBundle\Tests\Fixtures\Provider;
 
+use DateTimeImmutable;
+use IteratorAggregate;
 use SitemapGenerator\Entity\Url;
 use SitemapGenerator\Entity\Video;
-use SitemapGenerator\Provider\ProviderInterface;
-use SitemapGenerator\Sitemap\Sitemap;
 
-class TestProvider implements ProviderInterface
+class TestProvider implements IteratorAggregate
 {
-    public function populate(Sitemap $sitemap)
+    public function getIterator()
     {
-        $url = new Url();
-        $url->setLoc('http://www.google.fr');
-        $url->setChangefreq(Url::CHANGEFREQ_NEVER);
-        $url->setLastmod('2012-12-19 02:28');
+        $url = new Url('http://www.google.fr');
+        $url->setChangeFreq('never');
+        $url->setLastmod(new DateTimeImmutable('2012-12-19 02:28'));
 
-        $video = new Video();
-        $video->setThumbnailLoc('http://www.example.com/thumbs/123.jpg');
-        $video->setTitle('Grilling steaks for summer');
-        $video->setDescription('Alkis shows you how to get perfectly done steaks every time');
+        $video = new Video('Grilling steaks for summer', 'Alkis shows you how to get perfectly done steaks every time', 'http://www.example.com/thumbs/123.jpg');
         $url->addVideo($video);
 
-        $sitemap->add($url);
+        yield $url;
 
-        $url = new Url();
-        $url->setLoc('http://github.com');
-        $url->setChangefreq(Url::CHANGEFREQ_ALWAYS);
+        $url = new Url('http://github.com');
+        $url->setChangeFreq('always');
         $url->setPriority(0.2);
-        $sitemap->add($url);
+
+        yield $url;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,19 +12,19 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.1",
 
         "symfony/framework-bundle": "^3.4|^4.2",
         "symfony/console": "^3.4|^4.2",
-        "kphoen/sitemap-generator": "^1.0"
+        "kphoen/sitemap-generator": "^2.0"
     },
     "require-dev": {
-        "symfony/yaml": "^3.4|^4.2",
-        "symfony/translation": "^3.4|^4.2",
-        "symfony/validator": "^3.4|^4.2",
-        "symfony/browser-kit": "^3.4|^4.2",
-        "symfony/var-dumper": "^3.4|^4.2",
-        "phpunit/phpunit": "^6.4",
+        "symfony/yaml": "^3.4|^4.2|^5.0",
+        "symfony/translation": "^3.4|^4.2|^5.0",
+        "symfony/validator": "^^3.4|^4.2|5.0",
+        "symfony/browser-kit": "^3.4|^4.2|^5.0",
+        "symfony/var-dumper": "^3.4|^4.2|^5.0",
+        "phpunit/phpunit": "^7.5|^8.4",
         "kphoen/rusty": "dev-master"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,9 @@
     </testsuites>
 
     <php>
+        <ini name="error_reporting" value="-1" />
+        <server name="APP_ENV" value="test" force="true" />
+        <server name="SHELL_VERBOSITY" value="-1" />
         <server name="KERNEL_DIR" value="./Tests/Fixtures/App/app" />
         <server name="KERNEL_CLASS" value="AppKernel" />
     </php>


### PR DESCRIPTION
Predictably goes along with https://github.com/sitemap-php/SitemapGenerator/pull/12

- Expand Symfony constraints to support ^5.0
- Bumped minimum PHP version to 7.1
- Services defined as Symfony 3.3+
- `GenerateSitemapCommand` extends `Command` instead of `ContainerAwareCommand`
- Change the controller to be invokable
- Handle `TreeBuilder` 4.3+ deprecation
- Clean up test-harness
